### PR TITLE
Add alignment utilities

### DIFF
--- a/core/bootstrap-email.scss
+++ b/core/bootstrap-email.scss
@@ -16,4 +16,5 @@
 @import 'sass/color';
 @import 'sass/preview';
 @import 'sass/spacing';
+@import 'sass/align';
 @import 'sass/border';

--- a/core/sass/_align.scss
+++ b/core/sass/_align.scss
@@ -1,0 +1,6 @@
+.align-baseline    { vertical-align: baseline !important; } // Browser default
+.align-top         { vertical-align: top !important; }
+.align-middle      { vertical-align: middle !important; }
+.align-bottom      { vertical-align: bottom !important; }
+.align-text-bottom { vertical-align: text-bottom !important; }
+.align-text-top    { vertical-align: text-top !important; }


### PR DESCRIPTION
These would be useful, especially being able to apply `.align-middle` to a column, but as of now this conflicts with hardcoded `valign="top"` in the [column template](https://github.com/stuyam/bootstrap-email/blob/0.2.6/core/templates/col.html.erb#L1) and doesn't really accomplish anything.

In fact, the same conflict exists for the hardcoded `align="left"` and the existing `text-right` & `text-center` utilities, which won't actually apply since the `align` attribute wins.

I'd like to discuss removing those hardcoded `align` and `valign` attributes, unless there's some compelling reason why they need to be there.

I'd like to add docs for these if this will be accepted. Is there a process that generates the docs, or are they all hand-coded? Either way, it's beautiful documentation, so kudos for that! 💯 