### PR TITLE
Relax Ruby version in gemspec

### DIFF
--- a/bootstrap-email.gemspec
+++ b/bootstrap-email.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'premailer-rails', '~> 1.9'
   s.add_runtime_dependency 'rails', '>= 3'
 
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '>= 2.0'
 end


### PR DESCRIPTION
I want to bump ruby version to 3.0.0 in my rails application, bootstrap-emails ruby version is not supported for v3.0.0.
So I've relaxed ruby version in gemspec. Thanks.