### PR TITLE
Remove deprecated SASS syntax

### DIFF
--- a/core/scss/_functions.scss
+++ b/core/scss/_functions.scss
@@ -1,9 +1,11 @@
+@use 'sass:math';
+
 @mixin color-contrast($color) {
   $r: red($color);
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: math.div(($r * 299) + ($g * 587) + ($b * 114), 1000);
 
   @if ($yiq >= 150) {
     color: #111111;


### PR DESCRIPTION
Fixes this message from sass compiler:
```
Deprecation Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
Recommendation: math.div(($r * 299) + ($g * 587) + ($b * 114), 1000) or calc((($r * 299) + ($g * 587) + ($b * 114)) / 1000)
More info and automated migrator: https://sass-lang.com/d/slash-div
```