### PR TITLE
Add spec and support partial url tokens

### DIFF
--- a/lib/bootstrap-email/converters/support_url_tokens.rb
+++ b/lib/bootstrap-email/converters/support_url_tokens.rb
@@ -5,7 +5,7 @@ module BootstrapEmail
       CLOSE_BRACKETS = CGI.escape('}}').freeze
 
       def self.replace(html)
-        regex = /((href|src)=(\"|\'))((#{Regexp.quote(OPEN_BRACKETS)}).*?(#{Regexp.quote(CLOSE_BRACKETS)}))(\"|\')/
+        regex = /((href|src)=(\"|\').*?)((#{Regexp.quote(OPEN_BRACKETS)}).*?(#{Regexp.quote(CLOSE_BRACKETS)}))(.*?(\"|\'))/
         if regex.match?(html)
           html.gsub!(regex) do |match|
             "#{$1}#{CGI.unescape($4)}#{$7}"

--- a/spec/converters/support_url_tokens_spec.rb
+++ b/spec/converters/support_url_tokens_spec.rb
@@ -1,0 +1,41 @@
+require_relative '../spec_helper'
+
+RSpec.describe BootstrapEmail::Converter::SupportUrlTokens do
+  describe '#replace' do
+    it 'supports {{ tokens in src and hrefs' do
+      html = <<~HTML
+        <html>
+          <head></head>
+          <body>
+            <img src="{{ some_code_here }}">
+            <a href="{{ some_code_here }}">Link</a>
+          </body>
+        </html>
+      HTML
+      doc = Nokogiri::HTML(html)
+      html = doc.to_html(encoding: 'US-ASCII')
+      BootstrapEmail::Converter::SupportUrlTokens.replace(html)
+      expect(html.scan('<img src="{{ some_code_here }}">').one?).to eq(true)
+      expect(html.scan('<a href="{{ some_code_here }}">Link</a>').one?).to eq(true)
+    end
+
+    it 'supports {{ tokens before, after, and between in src and hrefs' do
+      html = <<~HTML
+        <html>
+          <head></head>
+          <body>
+            <img src="https://example.com/{{ some_code_here }}">
+            <a href="{{ some_code_here }}/example/com">Link</a>
+            <img src="https://example.com/{{ some_code_here }}/example/com">
+          </body>
+        </html>
+      HTML
+      doc = Nokogiri::HTML(html)
+      html = doc.to_html(encoding: 'US-ASCII')
+      BootstrapEmail::Converter::SupportUrlTokens.replace(html)
+      expect(html.scan('<img src="https://example.com/{{ some_code_here }}">').one?).to eq(true)
+      expect(html.scan('<a href="{{ some_code_here }}/example/com">Link</a>').one?).to eq(true)
+      expect(html.scan('<img src="https://example.com/{{ some_code_here }}/example/com">').one?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Support tokens before and after in urls per this issue: https://github.com/bootstrap-email/bootstrap-email/issues/160