### PR TITLE
Update the dependency specification for sassc

### DIFF
--- a/bootstrap-email.gemspec
+++ b/bootstrap-email.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'premailer', '~> 1.7'
-  s.add_runtime_dependency 'sassc', '~> 2.0'
+  s.add_runtime_dependency 'sassc', '~> 2.1'
   s.add_runtime_dependency 'htmlbeautifier', '~> 1.3'
 
   s.required_ruby_version = '>= 2.0'


### PR DESCRIPTION
Bootstrap-email uses the load_paths method to put it's load paths at the
front of the queue. This method was introduced in sassc 2.1.x so
updating the dependency to match.

This resolves the issue discussed in https://github.com/bootstrap-email/bootstrap-email/discussions/173#discussioncomment-2527023