### PR TITLE
Separate static and instance configuration

### DIFF
--- a/lib/bootstrap-email.rb
+++ b/lib/bootstrap-email.rb
@@ -16,6 +16,7 @@ rescue LoadError; end
 
 require 'action_mailer' if defined?(Rails)
 
+require_relative 'bootstrap-email/config_store'
 require_relative 'bootstrap-email/config'
 require_relative 'bootstrap-email/setup'
 require_relative 'bootstrap-email/erb'

--- a/lib/bootstrap-email/compiler.rb
+++ b/lib/bootstrap-email/compiler.rb
@@ -2,10 +2,10 @@
 
 module BootstrapEmail
   class Compiler
-    attr_accessor :type, :doc, :premailer
+    attr_accessor :type, :config, :doc, :premailer
 
     def initialize(input, type: :string, options: {})
-      BootstrapEmail.load_options(options)
+      self.config = BootstrapEmail::Config.new(options)
       self.type = type
       case type
       when :rails
@@ -41,11 +41,11 @@ module BootstrapEmail
     end
 
     def sass_load_paths
-      SassC.load_paths << BootstrapEmail.config.sass_load_paths
+      SassC.load_paths << config.sass_load_paths
     end
 
     def build_premailer_doc(html)
-      css_string = BootstrapEmail::SassCache.compile('bootstrap-email', style: :expanded)
+      css_string = BootstrapEmail::SassCache.compile('bootstrap-email', config, style: :expanded)
       self.premailer = Premailer.new(
         html,
         with_html_string: true,
@@ -86,7 +86,7 @@ module BootstrapEmail
     end
 
     def configure_html!
-      BootstrapEmail::Converter::HeadStyle.build(doc)
+      BootstrapEmail::Converter::HeadStyle.build(doc, config)
       BootstrapEmail::Converter::AddMissingMetaTags.build(doc)
       BootstrapEmail::Converter::VersionComment.build(doc)
     end

--- a/lib/bootstrap-email/config.rb
+++ b/lib/bootstrap-email/config.rb
@@ -2,7 +2,7 @@
 
 module BootstrapEmail
   class Config
-    def initialize(options)
+    def initialize(options = {})
       @config_store = BootstrapEmail::ConfigStore.new(options)
       file = File.expand_path('bootstrap-email.config.rb', Dir.pwd)
       if options[:config_path]

--- a/lib/bootstrap-email/config_store.rb
+++ b/lib/bootstrap-email/config_store.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module BootstrapEmail
+  class ConfigStore
+    OPTIONS = [
+      :sass_email_location, # path to main sass file
+      :sass_head_location,  # path to head sass file
+      :sass_load_paths,     # array of directories for loading sass imports
+      :sass_cache_location, # path to tmp folder for sass cache
+      :sass_log_enabled     # turn on or off sass log when caching new sass
+    ].freeze
+
+    attr_reader(*OPTIONS)
+
+    OPTIONS.each do |option|
+      define_method("#{option}=") do |value|
+        instance_variable_set("@#{option}", value)
+      end
+    end
+
+    def initialize(options = [])
+      options.each { |name, value| instance_variable_set("@#{name}", value) if OPTIONS.include?(name) }
+    end
+
+    def did_set?(option)
+      instance_variable_defined?("@#{option}")
+    end
+  end
+end

--- a/lib/bootstrap-email/converters/base.rb
+++ b/lib/bootstrap-email/converters/base.rb
@@ -10,8 +10,8 @@ module BootstrapEmail
         @cached_templates = {}
       end
 
-      def self.build(doc)
-        new(doc).build
+      def self.build(doc, *args)
+        new(doc).build(*args)
       end
 
       private

--- a/lib/bootstrap-email/converters/head_style.rb
+++ b/lib/bootstrap-email/converters/head_style.rb
@@ -3,7 +3,8 @@
 module BootstrapEmail
   module Converter
     class HeadStyle < Base
-      def build
+      def build(config)
+        @config = config
         doc.at_css('head').add_child(bootstrap_email_head)
       end
 
@@ -18,7 +19,7 @@ module BootstrapEmail
       end
 
       def purged_css_from_head
-        default, custom = BootstrapEmail::SassCache.compile('bootstrap-head').split('/*! allow_purge_after */')
+        default, custom = BootstrapEmail::SassCache.compile('bootstrap-head', @config).split('/*! allow_purge_after */')
         # get each CSS declaration
         custom.scan(/\w*\.[\w\-]*[\s\S\n]+?(?=})}{1}/).each do |group|
           # get the first class for each comma separated CSS declaration

--- a/lib/bootstrap-email/sass_cache.rb
+++ b/lib/bootstrap-email/sass_cache.rb
@@ -4,14 +4,15 @@ module BootstrapEmail
   class SassCache
     SASS_DIR = File.expand_path('../../core', __dir__)
 
-    def self.compile(type, style: :compressed)
-      new(type, style).compile
+    def self.compile(type, config, style: :compressed)
+      new(type, config, style).compile
     end
 
-    attr_accessor :type, :style, :file_path, :config_file, :checksum
+    attr_accessor :type, :config, :style, :file_path, :config_file, :checksum
 
-    def initialize(type, style)
+    def initialize(type, config, style)
       self.type = type
+      self.config = config
       self.style = style
       self.file_path = "#{SASS_DIR}/#{type}"
       self.config_file = load_config
@@ -19,7 +20,7 @@ module BootstrapEmail
     end
 
     def cache_dir
-      BootstrapEmail.config.sass_cache_location
+      config.sass_cache_location
     end
 
     def compile
@@ -31,7 +32,7 @@ module BootstrapEmail
     private
 
     def load_config
-      path = BootstrapEmail.config.sass_location_for(type: type)
+      path = config.sass_location_for(type: type)
       replace_config(File.read(path)) if path
     end
 
@@ -41,7 +42,7 @@ module BootstrapEmail
 
     def checksum_files
       checksums = config_file.nil? ? [] : [Digest::SHA1.hexdigest(config_file)]
-      BootstrapEmail.config.sass_load_paths.each do |load_path|
+      config.sass_load_paths.each do |load_path|
         Dir.glob(File.join(load_path, '**', '*.scss'), base: __dir__).each do |path|
           checksums << Digest::SHA1.file(File.expand_path(path, __dir__)).hexdigest
         end
@@ -59,7 +60,7 @@ module BootstrapEmail
       css = SassC::Engine.new(file, style: style).render
       FileUtils.mkdir_p("#{cache_dir}/#{checksum}") unless File.directory?("#{cache_dir}/#{checksum}")
       File.write(cache_path, css)
-      puts "New css file cached for #{type}" if BootstrapEmail.config.sass_log_enabled?
+      puts "New css file cached for #{type}" if config.sass_log_enabled?
     end
   end
 end

--- a/lib/bootstrap-email/setup.rb
+++ b/lib/bootstrap-email/setup.rb
@@ -15,7 +15,7 @@ module BootstrapEmail
     end
 
     def clear_sass_cache!
-      FileUtils.rm_rf(static_config.sass_cache_location)
+      FileUtils.rm_rf(BootstrapEmail::Config.new.sass_cache_location)
     end
   end
 end

--- a/lib/bootstrap-email/setup.rb
+++ b/lib/bootstrap-email/setup.rb
@@ -2,28 +2,20 @@
 
 module BootstrapEmail
   class << self
-    def config
-      @config ||= BootstrapEmail::Config.new
-      @config
-    end
-
-    def load_options(options)
-      @config ||= BootstrapEmail::Config.new
-      @config.load_options(options)
-      @config
+    def static_config
+      @static_config ||= BootstrapEmail::ConfigStore.new
     end
 
     def configure
-      @config ||= BootstrapEmail::Config.new
-      yield @config
+      yield static_config
     end
 
     def reset_config!
-      remove_instance_variable :@config if defined?(@config)
+      remove_instance_variable :@static_config if defined?(@static_config)
     end
 
     def clear_sass_cache!
-      FileUtils.rm_rf(BootstrapEmail.config.sass_cache_location)
+      FileUtils.rm_rf(static_config.sass_cache_location)
     end
   end
 end


### PR DESCRIPTION
This separates the concepts for "static" vs "instance" config. Any config you set via the `BootstrapEmail.configure do` method of settings config which also means when set that way in a custom config file, it will be set as static config that is global to all instances of Bootstrap Email being used. This is how it has always worked.

However the new changes is that config options being passed in when creating a new instance of the compiler such as `BootstrapEmail::Compiler.new(html, options: { sass_log_enabled: true })` will only be set to the instance of that compiler and not globally. Any settings not set in the instance will default to the global static config and further the defaults for the library if nothing is set.

The new `ConfigStore` class is for storing the data which can will be initialized in different places for the static vs instance config.