### PR TITLE
Support passing in custom sass as a string

### DIFF
--- a/lib/bootstrap-email/config.rb
+++ b/lib/bootstrap-email/config.rb
@@ -12,14 +12,20 @@ module BootstrapEmail
       end
     end
 
-    def sass_location_for(type:)
-      ivar_name = "sass_#{type.sub('bootstrap-', '')}_location"
-      option = config_for_option(ivar_name)
-      return option unless option.nil?
+    def sass_string_for(type:)
+      # look for custom sass string
+      sub_type = type.sub('bootstrap-', '')
+      string = config_for_option("sass_#{sub_type}_string")
+      return string unless string.nil?
 
+      # look for custom sass path
+      path = config_for_option("sass_#{sub_type}_location")
+      return File.read(path) unless path.nil?
+
+      # look up and return others if found in default locations
       lookup_locations = ["#{type}.scss", "app/assets/stylesheets/#{type}.scss"]
       locations = lookup_locations.map { |location| File.expand_path(location, Dir.pwd) }.select { |location| File.exist?(location) }
-      locations.first if locations.any?
+      File.read(locations.first) if locations.any?
     end
 
     def sass_load_paths

--- a/lib/bootstrap-email/config_store.rb
+++ b/lib/bootstrap-email/config_store.rb
@@ -5,6 +5,8 @@ module BootstrapEmail
     OPTIONS = [
       :sass_email_location, # path to main sass file
       :sass_head_location,  # path to head sass file
+      :sass_email_string,   # main sass file passed in as a string
+      :sass_head_string,    # head sass file passed in as a string
       :sass_load_paths,     # array of directories for loading sass imports
       :sass_cache_location, # path to tmp folder for sass cache
       :sass_log_enabled     # turn on or off sass log when caching new sass

--- a/spec/integrations/config_spec.rb
+++ b/spec/integrations/config_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe 'BootstrapEmail::Compiler#perform_full_compile' do
+  it 'processed the same emails with different sass defaults passed in' do
+    html = <<~HTML
+      <a href="https://bootstrapemail.com" class="btn btn-primary">Test</a>
+    HTML
+
+    sass_string = <<~SCSS
+      // Override all primary color to black
+      $primary: #000000;
+
+      //= @import bootstrap-email;
+    SCSS
+
+    output_1 = BootstrapEmail::Compiler.new(html).perform_full_compile
+    output_2 = BootstrapEmail::Compiler.new(html, options: { sass_email_string: sass_string }).perform_full_compile
+
+    expect(Nokogiri::HTML(output_1).at_css('a').attr('style')).to include('background-color: #0d6efd;')
+    expect(Nokogiri::HTML(output_2).at_css('a').attr('style')).to include('background-color: #000000;')
+  end
+end

--- a/spec/integrations/config_spec.rb
+++ b/spec/integrations/config_spec.rb
@@ -9,7 +9,7 @@ describe 'BootstrapEmail::Compiler#perform_full_compile' do
     HTML
 
     sass_string = <<~SCSS
-      // Override all primary color to black
+      // Override primary color to black
       $primary: #000000;
 
       //= @import bootstrap-email;


### PR DESCRIPTION
Bootstrap Email already supports passing in a `sass_email_location` or `sass_head_location` which can be used to point to a file that has custom sass vars.

This PR supports the ability to pass in the same but with the sass being passed in as a string of text rather than a location to the file with the new `sass_email_string` and `sass_head_string` config options.