### PR TITLE
Preview Text Expansion/Update

### DIFF
--- a/lib/bootstrap-email/converters/preview_text.rb
+++ b/lib/bootstrap-email/converters/preview_text.rb
@@ -8,7 +8,7 @@ module BootstrapEmail
         return if preview_node.nil?
 
         # apply spacing after the text max of 480 characters so it doesn't show body text
-        preview_node.inner_html += '&nbsp;&zwnj;' * [(480 - preview_node.content.length.to_i), 0].max
+        preview_node.inner_html += '&#847; &zwnj; &nbsp; ' * [(278 - preview_node.content.length.to_i), 0].max
         node = template('div', classes: 'preview', contents: preview_node.content)
         preview_node.remove
 

--- a/lib/bootstrap-email/converters/preview_text.rb
+++ b/lib/bootstrap-email/converters/preview_text.rb
@@ -7,7 +7,7 @@ module BootstrapEmail
         preview_node = doc.at_css('preview')
         return if preview_node.nil?
 
-        # apply spacing after the text max of 480 characters so it doesn't show body text
+        # apply spacing after the text max of 278 characters so it doesn't show body text
         preview_node.inner_html += '&#847; &zwnj; &nbsp; ' * [(278 - preview_node.content.length.to_i), 0].max
         node = template('div', classes: 'preview', contents: preview_node.content)
         preview_node.remove

--- a/lib/bootstrap-email/converters/preview_text.rb
+++ b/lib/bootstrap-email/converters/preview_text.rb
@@ -7,8 +7,8 @@ module BootstrapEmail
         preview_node = doc.at_css('preview')
         return if preview_node.nil?
 
-        # apply spacing after the text max of 100 characters so it doesn't show body text
-        preview_node.inner_html += '&nbsp;' * [(100 - preview_node.content.length.to_i), 0].max
+        # apply spacing after the text max of 480 characters so it doesn't show body text
+        preview_node.inner_html += '&nbsp;&zwnj;' * [(480 - preview_node.content.length.to_i), 0].max
         node = template('div', classes: 'preview', contents: preview_node.content)
         preview_node.remove
 


### PR DESCRIPTION
The current whitespace additions to the preview text was proving insufficient in a lot of scenarios (email body text was showing up awkwardly in previews), so I updated the converter according to some of Litmus's most recent recommendations as of Feb 2022:

https://www.litmus.com/blog/the-ultimate-guide-to-preview-text-support
https://www.litmus.com/blog/the-little-known-preview-text-hack-you-may-want-to-use-in-every-email/

With this update I've confirmed Gmail snippets in the most expanded view and Apple Mail with 5 preview lines show only the provided preview text.

It's my first time contributing to this project so just let me know if there are other things I need to do to make this merge-worthy 👍