### PR TITLE
Plain text support

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails-version: ['5.0', '5.1', '5.2', '6.0', '6.1', '7.0']
+        rails-version: ['4.2', '5.0', '5.1', '5.2', '6.0', '6.1', '7.0']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -1,0 +1,29 @@
+name: Rails
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rails-version: ['5.0', '5.1', '5.2', '6.0', '6.1', '7.0']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      with:
+        ruby-version: '2.7'
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        ACTION_MAILER_VERSION: ${{ matrix.rails-version }}
+    - name: Run tests
+      run: bundle exec rspec

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
+    - name: Set up Ruby & Rails
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
@@ -24,6 +24,7 @@ jobs:
       with:
         ruby-version: '2.7'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      env:
         ACTION_MAILER_VERSION: ${{ matrix.rails-version }}
     - name: Run tests
       run: bundle exec rspec

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails-version: ['4.2', '5.0', '5.1', '5.2', '6.0', '6.1', '7.0']
+        rails-version: ['5.0', '5.1', '5.2', '6.0', '6.1', '7.0']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -23,6 +23,7 @@ jobs:
       uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: '2.7'
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       env:
         ACTION_MAILER_VERSION: ${{ matrix.rails-version }}
     - name: Run tests

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -1,4 +1,4 @@
-name: ROR
+name: 🛤 Ruby on Rails
 
 on:
   push:
@@ -28,3 +28,5 @@ jobs:
         ACTION_MAILER_VERSION: ${{ matrix.rails-version }}
     - name: Run tests
       run: bundle exec rspec
+      env:
+        ACTION_MAILER_VERSION: ${{ matrix.rails-version }}

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -1,4 +1,4 @@
-name: Rails
+name: ROR
 
 on:
   push:

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -23,7 +23,6 @@ jobs:
       uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: '2.7'
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       env:
         ACTION_MAILER_VERSION: ${{ matrix.rails-version }}
     - name: Run tests

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -1,4 +1,4 @@
-name: 🛤 Ruby on Rails
+name: 🚂 Ruby on Rails
 
 on:
   push:

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -17,10 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby & Rails
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
+      # uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,10 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: 💎 Ruby
 
 on:
@@ -24,10 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
-      # uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: Ruby
+name: 💎 Ruby
 
 on:
   push:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ if rails_version == 'master'
   gem 'sprockets-rails', github: 'rails/sprockets-rails'
 else
   gem 'rails', "~> #{rails_version}"
+  gem 'sprockets-rails'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ if rails_version == 'master'
   gem 'sprockets-rails', github: 'rails/sprockets-rails'
 else
   gem 'rails', "~> #{rails_version}"
-  gem 'sprockets-rails'
+  gem 'sprockets-rails' if rails_version.to_i >= 7
 end

--- a/lib/bootstrap-email.rb
+++ b/lib/bootstrap-email.rb
@@ -29,4 +29,5 @@ Dir[File.join(__dir__, 'bootstrap-email/converters', '*.rb')].each { |file| requ
 if defined?(Rails)
   require_relative 'bootstrap-email/rails/action_mailer'
   require_relative 'bootstrap-email/rails/engine'
+  require_relative 'bootstrap-email/rails/hook'
 end

--- a/lib/bootstrap-email.rb
+++ b/lib/bootstrap-email.rb
@@ -29,5 +29,5 @@ Dir[File.join(__dir__, 'bootstrap-email/converters', '*.rb')].each { |file| requ
 if defined?(Rails)
   require_relative 'bootstrap-email/rails/action_mailer'
   require_relative 'bootstrap-email/rails/engine'
-  require_relative 'bootstrap-email/rails/hook'
+  require_relative 'bootstrap-email/rails/mail_builder'
 end

--- a/lib/bootstrap-email/bootstrap_email_cli.rb
+++ b/lib/bootstrap-email/bootstrap_email_cli.rb
@@ -42,6 +42,10 @@ parser = OptionParser.new do |opts|
     options[:config] = File.expand_path(v, Dir.pwd)
   end
 
+  opts.on('-t', '--text', 'Return the plain text version of the email.') do |v|
+    options[:plain_text] = true
+  end
+
   opts.on('-h', '--help', 'Prints this help') do
     puts opts
     exit
@@ -70,22 +74,23 @@ else
 end
 
 if input
+  method = options[:plain_text] ? :perform_text_compile : :perform_html_compile
   case options[:type]
   when :pattern
     Dir.glob(input, base: Dir.pwd).each do |path|
       next unless File.file?(path)
 
       puts "Compiling file #{path}"
-      compiled = BootstrapEmail::Compiler.new(path, type: :file, options: { config_path: options[:config] }).perform_full_compile
+      compiled = BootstrapEmail::Compiler.new(path, type: :file, options: { config_path: options[:config] }).public_send(method)
       destination = options[:destination].chomp('/*')
       FileUtils.mkdir_p("#{Dir.pwd}/#{destination}")
       File.write(File.expand_path("#{destination}/#{path.split('/').last}", Dir.pwd), compiled)
     end
   when :file
     path = File.expand_path(input, Dir.pwd)
-    puts BootstrapEmail::Compiler.new(path, type: :file, options: { config_path: options[:config], sass_log_enabled: false }).perform_full_compile
+    puts BootstrapEmail::Compiler.new(path, type: :file, options: { config_path: options[:config], sass_log_enabled: false }).public_send(method)
   when :string
-    puts BootstrapEmail::Compiler.new(input, options: { config_path: options[:config], sass_log_enabled: false }).perform_full_compile
+    puts BootstrapEmail::Compiler.new(input, options: { config_path: options[:config], sass_log_enabled: false }).public_send(method)
   end
 else
   puts opts

--- a/lib/bootstrap-email/compiler.rb
+++ b/lib/bootstrap-email/compiler.rb
@@ -19,21 +19,23 @@ module BootstrapEmail
     end
 
     def perform_multipart_compile
-      {
+      @perform_multipart_compile ||= {
         text: perform_text_compile,
         html: perform_html_compile
       }
     end
 
     def perform_text_compile
-      plain_text
+      @perform_text_compile ||= plain_text
     end
 
     def perform_html_compile
-      compile_html
-      inline_css
-      configure_html
-      finalize_document
+      @perform_html_compile ||= begin
+        compile_html
+        inline_css
+        configure_html
+        finalize_document
+      end
     end
     alias perform_full_compile perform_html_compile
 

--- a/lib/bootstrap-email/config_store.rb
+++ b/lib/bootstrap-email/config_store.rb
@@ -3,13 +3,14 @@
 module BootstrapEmail
   class ConfigStore
     OPTIONS = [
-      :sass_email_location, # path to main sass file
-      :sass_head_location,  # path to head sass file
-      :sass_email_string,   # main sass file passed in as a string
-      :sass_head_string,    # head sass file passed in as a string
-      :sass_load_paths,     # array of directories for loading sass imports
-      :sass_cache_location, # path to tmp folder for sass cache
-      :sass_log_enabled     # turn on or off sass log when caching new sass
+      :sass_email_location,     # path to main sass file
+      :sass_head_location,      # path to head sass file
+      :sass_email_string,       # main sass file passed in as a string
+      :sass_head_string,        # head sass file passed in as a string
+      :sass_load_paths,         # array of directories for loading sass imports
+      :sass_cache_location,     # path to tmp folder for sass cache
+      :sass_log_enabled,        # turn on or off sass log when caching new sass
+      :generate_rails_text_part # boolean for whether or not to generate the text part in rails, default: true
     ].freeze
 
     attr_reader(*OPTIONS)

--- a/lib/bootstrap-email/config_store.rb
+++ b/lib/bootstrap-email/config_store.rb
@@ -13,20 +13,21 @@ module BootstrapEmail
       :generate_rails_text_part # boolean for whether or not to generate the text part in rails, default: true
     ].freeze
 
-    attr_reader(*OPTIONS)
-
-    OPTIONS.each do |option|
-      define_method("#{option}=") do |value|
-        instance_variable_set("@#{option}", value)
-      end
-    end
+    attr_accessor(*OPTIONS)
 
     def initialize(options = [])
+      defaults
       options.each { |name, value| instance_variable_set("@#{name}", value) if OPTIONS.include?(name) }
     end
 
     def did_set?(option)
       instance_variable_defined?("@#{option}")
+    end
+
+    private
+
+    def defaults
+      self.generate_rails_text_part = true
     end
   end
 end

--- a/lib/bootstrap-email/rails/action_mailer.rb
+++ b/lib/bootstrap-email/rails/action_mailer.rb
@@ -5,11 +5,7 @@ ActiveSupport.on_load(:action_mailer, { yield: true }) do |action_mailer|
     # sit in the middle and compile the html
     def bootstrap_mail(*args, &block)
       mail_message = mail(*args, &block)
-      # if you override the #mail method in you ApplicationMailer you may intentionally return something other than a mail message
-      if mail_message
-        bootstrap = BootstrapEmail::Compiler.new(mail_message, type: :rails)
-        bootstrap.perform_full_compile
-      end
+      BootstrapEmail::Rails::Hook.new(mail_message).perform if mail_message
       mail_message
     end
     alias_method :bootstrap_email, :bootstrap_mail

--- a/lib/bootstrap-email/rails/action_mailer.rb
+++ b/lib/bootstrap-email/rails/action_mailer.rb
@@ -2,11 +2,9 @@
 
 ActiveSupport.on_load(:action_mailer, { yield: true }) do |action_mailer|
   action_mailer.class_eval do # To support Rails less than 6
-    # sit in the middle and compile the html
     def bootstrap_mail(*args, &block)
-      mail_message = mail(*args, &block)
-      BootstrapEmail::Rails::Hook.new(mail_message).perform if mail_message
-      mail_message
+      message = mail(*args, &block)
+      BootstrapEmail::Rails::MailBuilder.perform(message)
     end
     alias_method :bootstrap_email, :bootstrap_mail
     alias_method :make_bootstrap_mail, :bootstrap_mail

--- a/lib/bootstrap-email/rails/hook.rb
+++ b/lib/bootstrap-email/rails/hook.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module BootstrapEmail
+  module Rails
+    class Hook
+      attr_reader :mail, :bootstrap_email
+
+      def initialize(mail)
+        @mail = mail
+      end
+
+      def perform
+        @bootstrap_email = BootstrapEmail::Compiler.new(html_part, type: :string)
+        build_mail_parts
+      end
+
+      private
+
+      def build_mail_parts
+        if BootstrapEmail.static_config.generate_rails_text_part
+          mail.parts << build_alternative_part
+        else
+          html = bootstrap_email.perform_full_compile
+          mail.parts << build_html_part(html)
+        end
+      end
+
+      def html_part
+        (mail.html_part || mail).body.raw_source
+      end
+
+      def build_alternative_part
+        compiled = bootstrap_email.perform_multipart_compile
+
+        part = Mail::Part.new(content_type: 'multipart/alternative')
+        part.add_part(generate_text_part(compiled[:text]))
+        part.add_part(generate_html_part(compiled[:html]))
+
+        part
+      end
+
+      def build_html_part(html)
+        Mail::Part.new do
+          content_type "text/html; charset=#{html.encoding}"
+          body html
+        end
+      end
+
+      def build_text_part(text)
+        Mail::Part.new do
+          content_type "text/plain; charset=#{text.encoding}"
+          body text
+        end
+      end
+    end
+  end
+end

--- a/lib/bootstrap-email/rails/hook.rb
+++ b/lib/bootstrap-email/rails/hook.rb
@@ -33,8 +33,8 @@ module BootstrapEmail
         compiled = bootstrap_email.perform_multipart_compile
 
         part = Mail::Part.new(content_type: 'multipart/alternative')
-        part.add_part(generate_text_part(compiled[:text]))
-        part.add_part(generate_html_part(compiled[:html]))
+        part.add_part(build_text_part(compiled[:text]))
+        part.add_part(build_html_part(compiled[:html]))
 
         part
       end

--- a/lib/bootstrap-email/rails/mail_builder.rb
+++ b/lib/bootstrap-email/rails/mail_builder.rb
@@ -2,31 +2,37 @@
 
 module BootstrapEmail
   module Rails
-    class Hook
+    class MailBuilder
       attr_reader :mail, :bootstrap_email
 
-      def initialize(mail)
-        @mail = mail
-      end
-
-      def perform
-        @bootstrap_email = BootstrapEmail::Compiler.new(html_part, type: :string)
-        build_mail_parts
+      def self.perform(mail)
+        new(mail) if mail
       end
 
       private
 
-      def build_mail_parts
+      def initialize(mail)
+        @mail = mail
+        @bootstrap_email = BootstrapEmail::Compiler.new(html_part, type: :string)
+        perform
+      end
+
+      def perform
+        add_mail_parts
+        mail
+      end
+
+      def html_part
+        (mail.html_part || mail).body.raw_source
+      end
+
+      def add_mail_parts
         if BootstrapEmail.static_config.generate_rails_text_part
           mail.parts << build_alternative_part
         else
           html = bootstrap_email.perform_full_compile
           mail.parts << build_html_part(html)
         end
-      end
-
-      def html_part
-        (mail.html_part || mail).body.raw_source
       end
 
       def build_alternative_part

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -112,4 +112,15 @@ RSpec.describe BootstrapEmail::Compiler do
       expect(output.exclude?('content="text/html; charset=US-ASCII"')).to be true
     end
   end
+
+  describe '#perform_multipart_compile' do
+    it 'compiles a plain text and html email' do
+      output = BootstrapEmail::Compiler.new('<body>Hello there <a href="https://bootstrapemail.com">here is a link</a></body>').perform_multipart_compile
+      text = output[:text]
+      html = output[:html]
+      expect(text).to eq 'Hello there here is a link ( https://bootstrapemail.com )'
+      expect(text).not_to include '<a href="https://bootstrapemail.com"'
+      expect(html).to include '<a href="https://bootstrapemail.com"'
+    end
+  end
 end

--- a/spec/integrations/command_line_spec.rb
+++ b/spec/integrations/command_line_spec.rb
@@ -23,6 +23,12 @@ describe 'bootstrap-email' do
       .to_stdout_from_any_process
   end
 
+  it 'builds the email from a string and prints plain text' do
+    expect { system %(bootstrap-email -t -s '<a href="#" class="btn btn-primary">A very basic little button</a>') }
+      .to output("A very basic little button ( # )\n")
+      .to_stdout_from_any_process
+  end
+
   it 'builds the email from a file and does not print sass log' do
     BootstrapEmail.configure do |config|
       config.sass_cache_location = File.join(Dir.pwd, '.sass-cache', 'bootstrap-email')

--- a/spec/integrations/rails_spec.rb
+++ b/spec/integrations/rails_spec.rb
@@ -21,4 +21,17 @@ describe 'ActionMailer#bootstrap_mail' do
     expect(body).to be_present
     expect(body).to include(%(<p style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">Hello world</p>))
   end
+
+  it 'delivers a multipart email' do
+    WelcomeMailer.welcome_email('world').deliver_now
+
+    mail = ActionMailer::Base.deliveries.last
+    expect(mail).to be_present
+    html = mail.html_part.body.to_s
+    expect(html).to be_present
+    expect(html).to include(%(<p style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">Hello world</p>))
+    text = mail.text_part.body
+    expect(text).to be_present
+    expect(text).to eq 'Hello world'
+  end
 end

--- a/spec/integrations/rails_spec.rb
+++ b/spec/integrations/rails_spec.rb
@@ -34,4 +34,18 @@ describe 'ActionMailer#bootstrap_mail' do
     expect(text).to be_present
     expect(text).to eq 'Hello world'
   end
+
+  it 'turns off support for text parts in emails' do
+    BootstrapEmail.configure do |config|
+      config.generate_rails_text_part = false
+    end
+    WelcomeMailer.welcome_email('world').deliver_now
+
+    mail = ActionMailer::Base.deliveries.last
+    expect(mail).to be_present
+    html = mail.html_part.body.to_s
+    expect(html).to be_present
+    text = mail.text_part
+    expect(text).to be_nil
+  end
 end

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -4,7 +4,7 @@ require_relative 'boot'
 
 require 'action_mailer/railtie'
 require 'action_view/railtie'
-# require 'sprockets/railtie'
+require 'rails/railtie'
 require 'rails/test_unit/railtie'
 
 Bundler.require(*Rails.groups)

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -4,7 +4,8 @@ require_relative 'boot'
 
 require 'action_mailer/railtie'
 require 'action_view/railtie'
-require 'rails/railtie'
+require 'action_controller/railtie'
+require 'sprockets/railtie'
 require 'rails/test_unit/railtie'
 
 Bundler.require(*Rails.groups)

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -4,7 +4,7 @@ require_relative 'boot'
 
 require 'action_mailer/railtie'
 require 'action_view/railtie'
-require 'sprockets/railtie'
+# require 'sprockets/railtie'
 require 'rails/test_unit/railtie'
 
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
This adds support for getting a plain text version of the inputed email in addition to the html compiled version. It relies on premailer to get the plaintext version.

It also implements an intermediate rails hook class that creates emails by default with html and plain text versions in a multipart format. It allowed me to remove all rails specific logic from the compiler class and have it only rely on the hook class to build in mail part support

CC: @brunaportugal in issue #195 