### PR TITLE
Bug: Fix rails multipart support

### DIFF
--- a/lib/bootstrap-email/rails/mail_builder.rb
+++ b/lib/bootstrap-email/rails/mail_builder.rb
@@ -3,38 +3,50 @@
 module BootstrapEmail
   module Rails
     class MailBuilder
-      attr_reader :mail, :bootstrap_email
+      attr_reader :message, :bootstrap_email
 
       def self.perform(mail)
         new(mail).perform if mail
       end
 
       def initialize(mail)
-        @mail = mail
-        @bootstrap_email = BootstrapEmail::Compiler.new(html_part, type: :string)
+        @message = mail
+        @bootstrap_email = BootstrapEmail::Compiler.new(html_part.decoded, type: :string)
       end
 
       def perform
-        add_mail_parts
-        mail
+        replace_html_part(generate_html_part_replacement)
+        message
       end
 
       private
 
-      def html_part
-        (mail.html_part || mail).body.raw_source
+      # Much of this files derives from: https://github.com/fphilipe/premailer-rails/blob/2870060f9740de1c3f7a1da0acfc7b88e3181077/lib/premailer/rails/hook.rb
+
+      def message_contains_html?
+        html_part.present?
       end
 
-      def add_mail_parts
-        if BootstrapEmail.static_config.generate_rails_text_part
-          mail.parts << build_alternative_part
+      # Returns true if the message itself has a content type of text/html, thus
+      # it does not contain other parts such as alternatives and attachments.
+      def pure_html_message?
+        message.content_type&.include?('text/html')
+      end
+
+      def generate_html_part_replacement
+        if generate_text_part?
+          generate_alternative_part
         else
-          html = bootstrap_email.perform_full_compile
-          mail.parts << build_html_part(html)
+          html = bootstrap_email.perform_html_compile
+          build_html_part(html)
         end
       end
 
-      def build_alternative_part
+      def generate_text_part?
+        BootstrapEmail.static_config.generate_rails_text_part && !message.text_part
+      end
+
+      def generate_alternative_part
         compiled = bootstrap_email.perform_multipart_compile
 
         part = Mail::Part.new(content_type: 'multipart/alternative')
@@ -46,7 +58,7 @@ module BootstrapEmail
 
       def build_html_part(html)
         Mail::Part.new do
-          content_type "text/html; charset=#{html.encoding}"
+          content_type 'text/html; charset=UTF-8'
           body html
         end
       end
@@ -55,6 +67,47 @@ module BootstrapEmail
         Mail::Part.new do
           content_type "text/plain; charset=#{text.encoding}"
           body text
+        end
+      end
+
+      def html_part
+        if pure_html_message?
+          message
+        else
+          message.html_part
+        end
+      end
+
+      def replace_html_part(new_part)
+        if pure_html_message?
+          replace_in_pure_html_message(new_part)
+        else
+          replace_part_in_list(message.parts, html_part, new_part)
+        end
+      end
+
+      # If the new part is a pure text/html part, the body and its content type
+      # are used for the message. If the new part is
+      def replace_in_pure_html_message(new_part)
+        if new_part.content_type.include?('text/html')
+          message.body = new_part.decoded
+          message.content_type = new_part.content_type
+        else
+          message.body = nil
+          message.content_type = new_part.content_type
+          new_part.parts.each do |part|
+            message.add_part(part)
+          end
+        end
+      end
+
+      def replace_part_in_list(parts_list, old_part, new_part)
+        if (index = parts_list.index(old_part))
+          parts_list[index] = new_part
+        else
+          parts_list.any? do |part|
+            replace_part_in_list(part.parts, old_part, new_part) if part.respond_to?(:parts)
+          end
         end
       end
     end

--- a/spec/integrations/rails_spec.rb
+++ b/spec/integrations/rails_spec.rb
@@ -27,10 +27,10 @@ describe 'ActionMailer#bootstrap_mail' do
 
     mail = ActionMailer::Base.deliveries.last
     expect(mail).to be_present
-    html = mail.html_part.body.to_s
+    html = mail.html_part.decoded
     expect(html).to be_present
     expect(html).to include(%(<p style="line-height: 24px; font-size: 16px; width: 100%; margin: 0;" align="left">Hello world</p>))
-    text = mail.text_part.body
+    text = mail.text_part.decoded
     expect(text).to be_present
     expect(text).to eq 'Hello world'
   end
@@ -43,8 +43,9 @@ describe 'ActionMailer#bootstrap_mail' do
 
     mail = ActionMailer::Base.deliveries.last
     expect(mail).to be_present
-    html = mail.html_part.body.to_s
+    html = mail.body.to_s
     expect(html).to be_present
+    expect(mail.content_type).to include('text/html')
     text = mail.text_part
     expect(text).to be_nil
   end


### PR DESCRIPTION
Fixes: #199 
The multipart support wasn't replacing the correct `parts` in the email causing issues. I pulled over more the parts replacement code from: https://github.com/fphilipe/premailer-rails/blob/2870060f9740de1c3f7a1da0acfc7b88e3181077/lib/premailer/rails/hook.rb and that seemed to do the trick.