### PR TITLE
Transparent Green Bug: Unquote transparent color in sass

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Ruby & Rails
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '2.7'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       env:
         ACTION_MAILER_VERSION: ${{ matrix.rails-version }}

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Ruby & Rails
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3.0'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       env:
         ACTION_MAILER_VERSION: ${{ matrix.rails-version }}

--- a/core/scss/variables/_colors.scss
+++ b/core/scss/variables/_colors.scss
@@ -45,7 +45,7 @@ $theme-colors: (
 $palette-colors: (
   "black": $black,
   "white": $white,
-  "transparent": "transparent",
+  "transparent": transparent,
 
   "gray-100": $gray-100,
   "gray-200": $gray-200,


### PR DESCRIPTION
Fix for #202 

This was because the bgcolor was being rendered as `bgcolor="&quot;transparent&quot;"` which just totally broke the color and makes it render green for some reason. Removing the quotes from the keyword in the sass file fixes this so it renders like `bgcolor="transparent"`.