### PR TITLE
Fix bug where SASS load paths became nested arrays

### DIFF
--- a/lib/bootstrap-email/compiler.rb
+++ b/lib/bootstrap-email/compiler.rb
@@ -52,7 +52,11 @@ module BootstrapEmail
     end
 
     def sass_load_paths
-      SassC.load_paths << config.sass_load_paths
+      BootstrapEmail.config.sass_load_paths.each do |path|
+        SassC.load_paths << path
+      end
+
+      return SassC.load_paths
     end
 
     def build_premailer_doc(html)


### PR DESCRIPTION
By adding `BootstrapEmail.config.sass_load_paths`, which is an array, to `SassC.load_paths`, the two arrays are not joined but the first is added to the latter as a new array element. This leads to a nested array.

Nested array load paths can lead to exceptions during sass compilation, for instance when using Dart Sass via the Gem `sass-embedded`.